### PR TITLE
Build in windows

### DIFF
--- a/entry.py
+++ b/entry.py
@@ -6,6 +6,15 @@ from zhihurss.main import run
 __author__ = 'yuwei'
 
 if __name__ == '__main__':
-    path = os.path.dirname(os.path.abspath(__file__))
-    sys.path.insert(0, os.path.join(path, "zhihurss"))
+    if hasattr(sys, 'frozen') is False:
+        path = os.path.dirname(os.path.abspath(__file__))
+        sys.path.insert(0, os.path.join(path, "zhihurss"))
+    elif sys.platform == 'win32':
+        import win32api
+        ASADMIN = 'asadmin'
+
+        if sys.argv[-1] != ASADMIN:
+            params = ' '.join(sys.argv[1:] + [ASADMIN])
+            win32api.ShellExecute(0, 'runas', sys.executable, params, '', 1)
+            sys.exit(0)
     run()

--- a/entry.py
+++ b/entry.py
@@ -15,6 +15,6 @@ if __name__ == '__main__':
 
         if sys.argv[-1] != ASADMIN:
             params = ' '.join(sys.argv[1:] + [ASADMIN])
-            win32api.ShellExecute(0, 'runas', sys.executable, params, '', 1)
+            win32api.ShellExecute(0, 'runas', sys.executable, params, os.path.abspath(os.curdir), 1)
             sys.exit(0)
     run()

--- a/freeze.py
+++ b/freeze.py
@@ -4,8 +4,8 @@
 application_title = "zhihu-rss"
 main_python_file = "entry.py"
 
-import os
 import sys
+import os
 import shutil
 from distutils.sysconfig import get_python_lib
 
@@ -23,13 +23,21 @@ packages = [
     "PyQt5.QtNetwork"
 ]
 
-PYQT5_DIR = os.path.join(get_python_lib(), "PyQt5")
+QML_DIR = os.path.join(get_python_lib(), "PyQt5", 'qml')
+
+print('check QML dir: {0}'.format(QML_DIR), '...')
+
+if os.path.exists(QML_DIR) is False:
+    print("Can't find PyQt5's QML dir automatically, Please set it dir in freeze.py")
+    sys.exist(0)
+
+print('Done.')
 
 include_files = [
     ("zhihurss/res/qml/", "qml"),
-    (os.path.join(PYQT5_DIR, "qml", "QtQuick"), "QtQuick"),
-    (os.path.join(PYQT5_DIR, "qml", "QtQuick.2"), "QtQuick.2"),
-    (os.path.join(PYQT5_DIR, "qml", "QtWebKit"), "QtWebKit")
+    (os.path.join(QML_DIR, "QtQuick"), "QtQuick"),
+    (os.path.join(QML_DIR, "QtQuick.2"), "QtQuick.2"),
+    (os.path.join(QML_DIR, "QtWebKit"), "QtWebKit")
 ]
 
 base = None

--- a/freeze.py
+++ b/freeze.py
@@ -4,30 +4,41 @@
 application_title = "zhihu-rss"
 main_python_file = "entry.py"
 
-import sys
 import os
+import sys
 import shutil
+from distutils.sysconfig import get_python_lib
 
 from cx_Freeze import setup, Executable
-import PyQt5
 
 shutil.rmtree("build", ignore_errors=True)
 
-# 非常重要：不同系统位置不同，win 用 everything 来找QtQuick.2文件最好
-QML_DIR = "/usr/local/Cellar/qt5/5.4.1/qml/"
+packages = [
+    "zhihu",
+    "lxml",
+    "PyQt5.QtQuick",
+    "PyQt5.QtCore",
+    "PyQt5.QtWidgets",
+    "PyQt5.QtQml",
+    "PyQt5.QtNetwork"
+]
 
-includes_files = [
+PYQT5_DIR = os.path.join(get_python_lib(), "PyQt5")
+
+include_files = [
     ("zhihurss/res/qml/", "qml"),
-    (os.path.join(QML_DIR, "QtQuick.2"), "qml/QtQuick.2"),
-    (os.path.join(QML_DIR, "QtQuick"), "qml/QtQuick"),
-    (os.path.join(QML_DIR, "QtWebKit"), "qml/QtWebKit"),
-
+    (os.path.join(PYQT5_DIR, "qml", "QtQuick"), "QtQuick"),
+    (os.path.join(PYQT5_DIR, "qml", "QtQuick.2"), "QtQuick.2"),
+    (os.path.join(PYQT5_DIR, "qml", "QtWebKit"), "QtWebKit")
 ]
 
 base = None
+
 if sys.platform == "win32":
     base = "Win32GUI"
 
+with open('README.md', 'rb') as f:
+    readme = f.read().decode('utf-8')
 
 setup(
     name=application_title,
@@ -35,19 +46,12 @@ setup(
     url='https://github.com/SimplyY',
     author='SimplyY',
     description="zhihu-rss",
-    long_description=open('README.md', 'rb').read().decode('utf-8'),
-    zip_safe=False,
+    long_description=readme,
     options={
         "build_exe": {
-            "packages": {
-                "zhihu",
-                "PyQt5.QtQuick",
-                "PyQt5.QtCore",
-                "PyQt5.QtWidgets",
-                "PyQt5.QtQml",
-            },
-            "include_files": includes_files
+            "packages": packages,
+            "include_files": include_files
         }
     },
-    executables=[Executable(main_python_file, base=base), ],
+    executables=[Executable(main_python_file, base=base, targetName=application_title+'.exe')],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/7sDream/zhihu-py3.git#egg=zhihu [lxml]
+zhihu-py3[lxml]

--- a/setup.py
+++ b/setup.py
@@ -20,18 +20,13 @@ def extract_requirements(filename='requirements.txt'):
         lines = f_require.read().decode('utf-8').split('\n')
 
     # ignore comments and empty lines
-    require_lines = [
+    requires = [
         line
         for line in lines
         if line and not line.strip().startswith('#')
     ]
 
-    # separate dependency links from in-PyPI deps
-    links, reqs = [], []
-    for line in require_lines:
-        (links if '/' in line else reqs).append(line)
-
-    return links, reqs
+    return requires
 
 
 def extract_version():
@@ -52,7 +47,7 @@ with open('README.md', 'rb') as f_readme:
 
 
 version = extract_version()
-dep_links, requires = extract_requirements()
+requires = extract_requirements()
 
 
 setup(
@@ -69,7 +64,6 @@ setup(
     download_url='https://github.com/SimplyY/zhihu-py3/releases',
 
     install_requires=requires,
-    dependency_links=dep_links,
     packages=find_packages(),
     entry_points={
         'gui_scripts': [

--- a/zhihurss/control/add.py
+++ b/zhihurss/control/add.py
@@ -89,7 +89,3 @@ def show_add_dialog(my_app, qml, error_dialog):
     set_button(add_dialog.root_view, 'button_run',
                lambda: record_add_info(my_app, add_dialog, error_dialog, added_feeds))
     set_button(add_dialog.root_view, 'button_quit', lambda: quit_dialog(my_app, add_dialog, added_feeds))
-
-
-
-

--- a/zhihurss/control/add.py
+++ b/zhihurss/control/add.py
@@ -10,6 +10,7 @@ from ..model.noticer import Noticer
 from ..model.feeds_list import FeedsList
 from . import listview
 
+
 class AddedFeeds(QObject):
 
     def __init__(self):

--- a/zhihurss/model/feeds_list.py
+++ b/zhihurss/model/feeds_list.py
@@ -199,17 +199,16 @@ class FeedsList:
 
     @staticmethod
     def get_feeds_lists_in_json():
-
         with FeedsList.feeds_lists_json_lock:
-            if not os.path.exists(FEEDS_JSON_PATH):
-                with open(FEEDS_JSON_PATH, 'w'):
-                    return []
             try:
                 with open(FEEDS_JSON_PATH, 'rb') as f:
                     json_data = f.read().decode('utf-8')
-
             except FileNotFoundError:
-                return []
+                if os.path.exists(os.path.dirname(FEEDS_JSON_PATH)) is False:
+                    os.makedirs(os.path.dirname(FEEDS_JSON_PATH))
+                with open(FEEDS_JSON_PATH, 'w'):
+                    return []
+
         if json_data:
             data = json.loads(json_data)
         else:

--- a/zhihurss/model/noticer.py
+++ b/zhihurss/model/noticer.py
@@ -83,10 +83,6 @@ class Noticer:
     @staticmethod
     def get_noticers_in_json():
         with Noticer.noticers_json_lock:
-            if not os.path.exists(NOTICERS_JSON_PATH):
-                with open(NOTICERS_JSON_PATH, 'w'):
-                    return []
-
             try:
                 with open(NOTICERS_JSON_PATH, 'rb') as f:
                     file = f.read().decode('utf-8')
@@ -98,9 +94,11 @@ class Noticer:
                         return [Noticer(noticer_list=noticer_list) for noticer_list in data]
                     else:
                         return []
-            except FileNotFoundError:
-                # TODO: log
-                pass
+            except FileNotFoundError:   # first run or delete config file
+                if os.path.exists(os.path.dirname(NOTICERS_JSON_PATH)) is False:
+                    os.makedirs(os.path.dirname(NOTICERS_JSON_PATH))
+                with open(NOTICERS_JSON_PATH, 'w'):
+                    return []
 
         return []
 

--- a/zhihurss/util/const.py
+++ b/zhihurss/util/const.py
@@ -11,8 +11,8 @@ else:
     QML_ROOT = os.path.join(BASE_DIR, 'res', 'qml')
 
 
-NOTICERS_FILE = os.path.join('~', '.config', 'zhihurss', 'noticers.json')
-FEEDS_FILE = os.path.join('~', '.cache', 'zhihurss', 'feeds.json')
+NOTICERS_FILE = os.path.join(BASE_DIR, 'config', 'noticers.json')
+FEEDS_FILE = os.path.join(BASE_DIR, 'cache', 'feeds.json')
 
 
 MAIN_QML_PATH = os.path.join(QML_ROOT, 'main.qml')
@@ -20,8 +20,5 @@ ADD_QML_PATH = os.path.join(QML_ROOT, 'add.qml')
 ERROR_QML_PATH = os.path.join(QML_ROOT, 'error.qml')
 CHANGE_QML_PATH = os.path.join(QML_ROOT, 'change.qml')
 
-
-NOTICERS_JSON_PATH = os.path.expanduser(NOTICERS_FILE)
-FEEDS_JSON_PATH = os.path.expanduser(FEEDS_FILE)
 
 CSS_GITHUB_PATH = "https://raw.githubusercontent.com/SimplyY/save/master/github-markdown.css"

--- a/zhihurss/util/const.py
+++ b/zhihurss/util/const.py
@@ -11,9 +11,8 @@ else:
     QML_ROOT = os.path.join(BASE_DIR, 'res', 'qml')
 
 
-NOTICERS_FILE = '~/.config/zhihurss/noticers.json'
-FEEDS_FILE = '~/.cache/zhihurss/feeds.json'
-
+NOTICERS_FILE = os.path.join('~', '.config', 'zhihurss', 'noticers.json')
+FEEDS_FILE = os.path.join('~', '.cache', 'zhihurss', 'feeds.json')
 
 
 MAIN_QML_PATH = os.path.join(QML_ROOT, 'main.qml')

--- a/zhihurss/util/const.py
+++ b/zhihurss/util/const.py
@@ -11,8 +11,8 @@ else:
     QML_ROOT = os.path.join(BASE_DIR, 'res', 'qml')
 
 
-NOTICERS_FILE = os.path.join(BASE_DIR, 'config', 'noticers.json')
-FEEDS_FILE = os.path.join(BASE_DIR, 'cache', 'feeds.json')
+NOTICERS_JSON_PATH = os.path.join(BASE_DIR, 'config', 'noticers.json')
+FEEDS_JSON_PATH = os.path.join(BASE_DIR, 'cache', 'feeds.json')
 
 
 MAIN_QML_PATH = os.path.join(QML_ROOT, 'main.qml')

--- a/zhihurss/util/my_pyqt.py
+++ b/zhihurss/util/my_pyqt.py
@@ -24,7 +24,7 @@ class MyApp(QObject):
         if set_context:
             set_context(self.root_context)
 
-        self.engine.load(QUrl(qml))
+        self.engine.load(QUrl.fromLocalFile(qml))
         self.root_view = self.engine.rootObjects()[0]
 
     @staticmethod
@@ -41,11 +41,10 @@ class MyView(QQuickView):
         self.root_context = self.rootContext()
 
         if qml:
-            self.setSource(QUrl(qml))
-            self.root_view = self.rootObject()
+            self.set_qml(qml)
 
     def set_qml(self, qml):
-        self.setSource(QUrl(qml))
+        self.setSource(QUrl.fromLocalFile(qml))
         self.root_view = self.rootObject()
 
 
@@ -58,6 +57,7 @@ def set_button(parent_view, object_name, function=None):
     if function:
         button.clicked.connect(function)
 
+
 def set_menu(parent_view, object_name, function=None):
     menu = find_view(parent_view, object_name)
     if function:
@@ -68,5 +68,3 @@ def use_qml_fun(root_view, fun_parent_name, fun_name, args):
     parent_view = root_view.findChild(QObject, fun_parent_name)
     q_arg = QVariant(args)
     QMetaObject.invokeMethod(parent_view, fun_name, Qt.DirectConnection, Q_ARG(QVariant, q_arg))
-
-


### PR DESCRIPTION
# 更改描述
## entry.py
- 添加目录到环境变量的语句仅在脚本形式运行时需要
- 当为Windows EXE形式运行时请求管理员权限
## freeze.py
- 尝试自动获取PyQt5 QML目录地址
- 增加没自动放进去的lxml package，这是造成URL无效错误的原因
- 修改生成的exe文件名
## reqirement.txt
- 改为pip形式
## setup.py
- extract_require 改为pip形式
## zhihurss/model/feed_list.py
- 第一次运行时自动创建目录和空feeds.json文件
## zhihurss/model/noticer.py
- 第一次运行时自动创建目录和空noticers.json文件
## zhihurss/util/const.py
- NOTICERS_JSON_PATH，FEEDS_JSON_PATH从用户目录改到当前目录
## zhihurss/util/my_pyqt.py
- QUrl(qml) --> QUrl.fromLocalFile(qml) 查了文档，这样在win上就不会报错了，相信OSX，Linux也不会
